### PR TITLE
use `ln(x + 1)` instead of `sqrt(x)` for XP orb size calculation

### DIFF
--- a/src/main/java/surreal/fixeroo/core/FixerooHooks.java
+++ b/src/main/java/surreal/fixeroo/core/FixerooHooks.java
@@ -22,7 +22,6 @@ import net.minecraft.util.EnumHand;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.AxisAlignedBB;
 import net.minecraft.util.math.BlockPos;
-import net.minecraft.util.math.MathHelper;
 import net.minecraft.world.World;
 import net.minecraftforge.common.util.Constants;
 import net.minecraftforge.oredict.OreDictionary;
@@ -64,7 +63,7 @@ public class FixerooHooks {
 
     public static float RenderXPOrb$getSize(EntityXPOrb orb) {
         int xpValue = orb.xpValue;
-        return Math.max(0.3F, MathHelper.sqrt(xpValue) / 100);
+        return Math.max(0.3F, Math.log(xpValue + 1) / 100);
     }
 
     // Golem Tweaks

--- a/src/main/java/surreal/fixeroo/core/FixerooHooks.java
+++ b/src/main/java/surreal/fixeroo/core/FixerooHooks.java
@@ -63,7 +63,7 @@ public class FixerooHooks {
 
     public static float RenderXPOrb$getSize(EntityXPOrb orb) {
         int xpValue = orb.xpValue;
-        return Math.max(0.3F, Math.log(xpValue + 1) / 100);
+        return Math.max(0.3F, (float) Math.log(xpValue + 1) / 100);
     }
 
     // Golem Tweaks


### PR DESCRIPTION
`sqrt()` is not enough for handling XP orbs with extra large amount of experience value, making them very large visually.

This PR changed it to `ln(x+1)` (Math.log() in Java), which can provide a much smaller output when input is huge.

Note: `ln(x + 1)` instead `ln(x)` is used because when x = 0, ln(x) = NaN. Despite an XP orb with no experience should be impossible, but just in case.